### PR TITLE
api: Remove enmeshed configuration

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -63,12 +63,6 @@ module "api" {
     }
     google_service_account = file("secrets/serlo-org-6bab84a1b1a5.json")
     sentry_dsn             = "https://dd6355782e894e048723194b237baa39@o115070.ingest.sentry.io/5385534"
-
-    enmeshed = {
-      host           = ""
-      server_secret  = ""
-      webhook_secret = ""
-    }
   }
 
   swr_queue_worker = {

--- a/api.tf
+++ b/api.tf
@@ -18,7 +18,7 @@ module "api_redis" {
 }
 
 module "api" {
-  source = "github.com/serlo/infrastructure-modules-api.git//?ref=v9.2.0"
+  source = "github.com/serlo/infrastructure-modules-api.git//?ref=v10.0.0"
 
   namespace         = kubernetes_namespace.api_namespace.metadata.0.name
   image_tag         = local.api.image_tags.server
@@ -55,8 +55,11 @@ module "api" {
   }
 
   server = {
-    hydra_host  = module.hydra.admin_uri
-    kratos_host = ""
+    hydra_host         = module.hydra.admin_uri
+    kratos_host        = ""
+    kratos_admin_host  = ""
+    kratos_public_host = ""
+    kratos_secret      = ""
     swr_queue_dashboard = {
       username = var.api_swr_queue_dashboard_username
       password = var.api_swr_queue_dashboard_password


### PR DESCRIPTION
Wait for [https://github.com/serlo/infrastructure-modules-shared/pull/28 and ](https://github.com/serlo/infrastructure-modules-api/pull/16) since the line https://github.com/serlo/infrastructure-env-production/blob/main/api.tf#L21 needs to be updated afterwards