### PR TITLE
Upgrade redis module

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -10,7 +10,7 @@ locals {
 }
 
 module "api_redis" {
-  source = "github.com/serlo/infrastructure-modules-shared.git//redis?ref=v13.2.0"
+  source = "github.com/serlo/infrastructure-modules-shared.git//redis?ref=v17.1.2"
 
   namespace     = kubernetes_namespace.api_namespace.metadata.0.name
   chart_version = "12.6.2"


### PR DESCRIPTION
Even though I've manually updated the terraform state, also chaning the `"status"` to "deployed" it still gets the following error:
```
  # module.api_redis.helm_release.redis will be updated in-place
  ~ resource "helm_release" "redis" {
        id                         = "redis"
        name                       = "redis"
      ~ status                     = "failed" -> "deployed"
        # (26 unchanged attributes hidden)

        # (10 unchanged blocks hidden)
    }
```