### PR TITLE
(deployment): Bump the version of the `infrastructure-modules-api` module

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -19,7 +19,7 @@ module "api_redis" {
 }
 
 module "api" {
-  source = "github.com/serlo/infrastructure-modules-api.git//?ref=v10.4.0"
+  source = "github.com/serlo/infrastructure-modules-api.git//?ref=v10.5.1"
 
   namespace         = kubernetes_namespace.api_namespace.metadata.0.name
   image_tag         = local.api.image_tags.server


### PR DESCRIPTION
This version includes the new health probe for the `server(api)` container that is needed to function with version 4 of the Apollo Server.