### PR TITLE
(deployment): Bump the version of database_layer and server

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -1,8 +1,8 @@
 locals {
   api = {
     image_tags = {
-      database_layer   = "0.3.69"
-      server           = "0.54.0"
+      database_layer   = "0.3.70"
+      server           = "0.56.0"
       api_db_migration = "0.3.0"
     }
   }


### PR DESCRIPTION
These versions include support for the `status` field in Threads. 
The change was already applied.